### PR TITLE
v10.0.1-beta.4

### DIFF
--- a/.github/workflows/release-pipeline.yml
+++ b/.github/workflows/release-pipeline.yml
@@ -61,7 +61,7 @@ jobs:
         uses: softprops/action-gh-release@v2
         with:
           tag_name: ${{ github.event.pull_request.title }}
-          name: Release ${{ github.event.pull_request.title }}
+          name: ${{ github.event.pull_request.title }}
           prerelease: ${{ steps.check_type.outputs.IS_PRERELEASE }}
           generate_release_notes: true
 

--- a/.github/workflows/update-manifest.yml
+++ b/.github/workflows/update-manifest.yml
@@ -21,7 +21,7 @@ jobs:
     steps:
       - name: Post-Release Step
         run: |
-          echo "Release v${{ inputs.version }} is released"
+          echo "Release ${{ inputs.version }} is released"
 
       - name: Create GitHub App token
         id: app-token

--- a/.github/workflows/windows-build-nsis.yml
+++ b/.github/workflows/windows-build-nsis.yml
@@ -148,7 +148,7 @@ jobs:
       if: ${{ inputs.version != '' }}
       uses: softprops/action-gh-release@v2
       with:
-        tag_name: v${{ inputs.version }}
+        tag_name: ${{ inputs.version }}
         files: installer/Huntarr-*-win.exe
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Remove redundant 'v' and 'Release' prefixes from workflow outputs and tags.

